### PR TITLE
Response parsing corrected

### DIFF
--- a/smsactivateru/actions.py
+++ b/smsactivateru/actions.py
@@ -79,8 +79,8 @@ class GetStatus(ActionsModel):
 	def __response_processing(self, response):
 		data = {'status': response, 'code': None}
 		if ':' in response:
-			data['status'] = response.split(':')[0]
-			data['code'] = response.split(':')[1]
+			data['status'] = response.split(':', 1)[0]
+			data['code'] = response.split(':', 1)[1]
 		return data
 
 	def request(self, wrapper):


### PR DESCRIPTION
When AnyOther service used, sms code may contain any characters, including colon ':'. For examle, today google sends activation code as "Yo.ur c.ode is: 123456". There was no ability to receive this code before this commit - I received only "Yo.ur c.ode is". So, when parsing response, it's important to use split only at first colon.