### PR TITLE
Use SSL endpoint

### DIFF
--- a/smsactivateru/sms.py
+++ b/smsactivateru/sms.py
@@ -5,7 +5,7 @@ import requests
 class Sms:
 	def __init__(self, api_key):
 		self.key = api_key
-		self.url = 'http://sms-activate.ru/stubs/handler_api.php'
+		self.url = 'https://sms-activate.ru/stubs/handler_api.php'
 
 	def request(self, action):
 		try:


### PR DESCRIPTION
API key is always provided via GET parameter. It's not secure to transmit it as plain data.